### PR TITLE
Prevent notices on file-save if backups enabled

### DIFF
--- a/ProcessFileEdit.module.php
+++ b/ProcessFileEdit.module.php
@@ -170,7 +170,7 @@ class ProcessFileEdit extends Process {
 				if(trim($this->backupExtension) !== "") {
 					$f = str_replace("/", "/.", $filebase);
 					$dest = $this->dirPath . $f . $this->backupExtension;
-					copy($file, $dest);
+					@copy($file, $dest);
 				}
 
 				if($fileHandle = @fopen($file, "w+")) {


### PR DESCRIPTION
If the process running the code does not have permissions to write the copy into the directory, then we might want to prevent the notice in the admin interface.