### PR TITLE
More robust handling of backup extension

### DIFF
--- a/ProcessFileEdit.module.php
+++ b/ProcessFileEdit.module.php
@@ -169,6 +169,9 @@ class ProcessFileEdit extends Process {
 
 				if(trim($this->backupExtension) !== "") {
 					$f = str_replace("/", "/.", $filebase);
+					if (0 !== strpos($this->backupExtension, '.')) {
+						$this->backupExtension = '.' . $this->backupExtension;
+					}
 					$dest = $this->dirPath . $f . $this->backupExtension;
 					copy($file, $dest);
 				}


### PR DESCRIPTION
Prepend a '.' to the backup extension, if needed.

Currently, file 'styles.css' and backupExtension of 'old' lead to a backup called 'styles.cssold'. This might be intentional, but I suspect having it lead to 'styles.css.old' is probably more useful.